### PR TITLE
fix(code-field): align line numbers with wrapped text lines

### DIFF
--- a/lib/src/line_numbers/line_number_controller.dart
+++ b/lib/src/line_numbers/line_number_controller.dart
@@ -18,14 +18,19 @@ class LineNumberController extends TextEditingController {
 
     for (int k = 0; k < list.length; k++) {
       final el = list[k];
-      final number = int.parse(el);
-      var textSpan = TextSpan(text: el, style: style);
-
-      if (lineNumberBuilder != null) {
-        textSpan = lineNumberBuilder!(number, style);
+      // Blank lines are placeholders inserted to align with wrapped
+      // visual lines. They should render as empty text spans to
+      // preserve vertical spacing.
+      if (el.trim().isEmpty) {
+        children.add(TextSpan(text: '', style: style));
+      } else {
+        final number = int.tryParse(el) ?? 0;
+        var textSpan = TextSpan(text: el, style: style);
+        if (lineNumberBuilder != null && number != 0) {
+          textSpan = lineNumberBuilder!(number, style);
+        }
+        children.add(textSpan);
       }
-
-      children.add(textSpan);
       if (k < list.length - 1) {
         children.add(const TextSpan(text: '\n'));
       }


### PR DESCRIPTION
When wrap=true, long lines create multiple visual rows but line numbers only showed logical line count. Now TextPainter measures each line's visual height and inserts blank placeholders to keep line numbers synchronized with wrapped content.

- Calculate visual line count using TextPainter.layout()
- Insert empty line number placeholders for wrapped visual lines
- Recalculate on width changes to maintain alignment
- Handle non-numeric placeholders in LineNumberController